### PR TITLE
Docs: Fix link to parent state styles

### DIFF
--- a/apps/website/docs/home.md
+++ b/apps/website/docs/home.md
@@ -28,7 +28,7 @@ NativeWind achieves this by pre-compiling your styles and uses a minimal runtime
 
 ✨ **Pseudo classes** hover / focus / active on compatible components [(docs)](../core-concepts/states#hover-focus-and-active)
 
-👪 **Parent state styles** automatically style children based upon parent pseudo classes [(docs)](../core-concepts/states#hover-focus-and-active#styling-based-on-parent-state)
+👪 **Parent state styles** automatically style children based upon parent pseudo classes [(docs)](../core-concepts/states#styling-based-on-parent-state)
 
 ## In action
 


### PR DESCRIPTION
A quick typo fix for the link leading to [Parent state styles](https://www.nativewind.dev/core-concepts/states#styling-based-on-parent-state) page