### PR TITLE
fix tailwind intellisense error : endsWith is not a function

### DIFF
--- a/packages/nativewind/src/tailwind/native/line-height.ts
+++ b/packages/nativewind/src/tailwind/native/line-height.ts
@@ -7,6 +7,9 @@ export const lineHeight: CustomPluginFunction = (
   matchUtilities(
     {
       leading(value: string) {
+        if(typeof value !== "string") {
+          return notSupported(`leading-${value}`)();
+        }
         if (value.endsWith("px")) {
           return { lineHeight: value };
         }


### PR DESCRIPTION
Using tailwindcssReactNative plugin in the tailwind.config.js with the VSCode plugin Tailwind CSS IntelliSense cause an error on starting.

The function leading receive a boolean instead of a string and and errors is throw with the call of value.endsWith.

I have just added a type check in the function.