### PR TITLE
fix `useSyncExternalStoreWithSelector` missing `getServerSnapshot` argument

### DIFF
--- a/packages/nativewind/src/styled/use-tailwind.ts
+++ b/packages/nativewind/src/styled/use-tailwind.ts
@@ -63,7 +63,7 @@ export function useTailwind<T>({
   const styles = useSyncExternalStoreWithSelector(
     subscribe,
     getSnapshot,
-    undefined,
+    getSnapshot,
     selector
   );
 


### PR DESCRIPTION
When working with next.js ssr, `useSyncExternalStoreWithSelector` requires the `getServerSnapshot` argument, otherwise an [error](https://github.com/marklawlor/nativewind/discussions/141#discussioncomment-3315674) will be thrown.

