### PR TITLE
chore(docs): add require in nextjs setup

### DIFF
--- a/apps/website/docs/quick-starts/nextjs.md
+++ b/apps/website/docs/quick-starts/nextjs.md
@@ -15,7 +15,7 @@ module.exports = {
   content: [
     './pages/**/*.{js,jsx,ts,tsx}',
   ],
-+ plugins: ['nativewind/tailwind/css'],
++ plugins: [require('nativewind/tailwind/css')],
   theme: {
     extend: {},
   },
@@ -51,7 +51,7 @@ module.exports = {
   content: [
     './pages/**/*.{js,jsx,ts,tsx}',
   ],
-  plugins: ['nativewind/tailwind/css'],
+  plugins: [require('nativewind/tailwind/css')],
 + important: 'html',
   theme: {
     extend: {},


### PR DESCRIPTION
First of all, thanks a lot for this amazing work, we just started migrating our project to nativewind and everything is looking great so far.

However, we were running into problems using the `parent` variant on next as it was not doing anything. Fortunately requiring the plugin explicitly worked for us and I wanted to make it a bit clear in the docs.

I don't understand how tailwind's plugin system works, but looking at the config types and their docs, it seems that it doesn't accept strings.