### PR TITLE
Point out postcss-loader version in Webpack warning

### DIFF
--- a/apps/website/docs/quick-starts/expo.md
+++ b/apps/website/docs/quick-starts/expo.md
@@ -72,7 +72,7 @@ You will need follow a [Tailwind CSS installation guide](https://tailwindcss.com
 
 :::caution
 
-Expo Web only supports Webpack 4, please ensure you are only installing webpack loaders that that support Webpack 4.
+Expo Web only supports Webpack 4, please ensure you are only installing webpack loaders that that support Webpack 4. For example, The latest version of `postcss-loader` is not compatible with Webpack 4 and instead, `postcss-loader@4.2.0` should be used.
 
 https://github.com/expo/expo-cli/pull/3763
 


### PR DESCRIPTION
Added note about postcss-loader version as per our conversation here #218.