### PR TITLE
chore(docs): fix confusing View component remove and add for rn-cli

### DIFF
--- a/apps/website/docs/quick-starts/react-native-cli.md
+++ b/apps/website/docs/quick-starts/react-native-cli.md
@@ -126,11 +126,11 @@ const App: () => Node = () => {
 -       style={backgroundStyle}>
 +       className={backgroundStyle}>
         <Header />
-        <View
+-        <View
 -         style={{
 -           backgroundColor: isDarkMode ? Colors.black : Colors.white,
 -         }}>
-+         className="bg-white dark:bg-black"
++       <View className="bg-white dark:bg-black">
           <Section title="Step One">
 -           Edit <Text style={styles.highlight}>App.js</Text> to change this
 +           Edit <Text className="font-bold">App.js</Text> to change this


### PR DESCRIPTION
This package is awesome. Kudos to you @marklawlor and all of the maintainers.

While I'm following the docs for react-native cli, I saw that there is a confusing class insertion outside a View component tag. I just want it to be clear by creating this PR.

![image](https://user-images.githubusercontent.com/20082606/188252271-4b01b596-f30a-4770-b2de-e425e80bdfce.png)

Thanks in advance