### PR TITLE
Check for empty `safelist` array instead of undefined

### DIFF
--- a/.changeset/popular-onions-visit.md
+++ b/.changeset/popular-onions-visit.md
@@ -1,0 +1,5 @@
+---
+"nativewind": patch
+---
+
+fix: unable to find styles console warning

--- a/packages/nativewind/src/babel/index.ts
+++ b/packages/nativewind/src/babel/index.ts
@@ -132,8 +132,11 @@ export default function (
 
         // If the file doesn't have any Tailwind styles, it will print a warning
         // We force an empty style to prevent this
-        const safelist = tailwindConfig.safelist.length > 0 ? tailwindConfig.safelist : ["babel-empty"]
-        
+        const safelist =
+          tailwindConfig.safelist && tailwindConfig.safelist.length > 0
+            ? tailwindConfig.safelist
+            : ["babel-empty"];
+
         const output = extractStyles({
           ...tailwindConfig,
           content: [filename],

--- a/packages/nativewind/src/babel/index.ts
+++ b/packages/nativewind/src/babel/index.ts
@@ -130,12 +130,14 @@ export default function (
 
         if (!canCompile) return;
 
+        const safelist = tailwindConfig.safelist.length > 0 ? tailwindConfig.safelist : ["babel-empty"]
+        
         const output = extractStyles({
           ...tailwindConfig,
           content: [filename],
           // If the file doesn't have any Tailwind styles, it will print a warning
           // We force an empty style to prevent this
-          safelist: tailwindConfig.safelist ?? ["babel-empty"],
+          safelist,
         });
 
         if (!output.hasStyles) return;

--- a/packages/nativewind/src/babel/index.ts
+++ b/packages/nativewind/src/babel/index.ts
@@ -130,13 +130,13 @@ export default function (
 
         if (!canCompile) return;
 
+        // If the file doesn't have any Tailwind styles, it will print a warning
+        // We force an empty style to prevent this
         const safelist = tailwindConfig.safelist.length > 0 ? tailwindConfig.safelist : ["babel-empty"]
         
         const output = extractStyles({
           ...tailwindConfig,
           content: [filename],
-          // If the file doesn't have any Tailwind styles, it will print a warning
-          // We force an empty style to prevent this
           safelist,
         });
 


### PR DESCRIPTION
Hi there, thanks for working on nativewind. Its a lot of fun to use!

I have been running into #67 for files without tailwind styles. I found that `safelist` has a default value of an empty array and therefore the default `babel-empty` class wasn't set.

https://github.com/marklawlor/nativewind/blob/9481eb58c368ac4c6d5760cb1897b542e7e17fd1/packages/nativewind/src/babel/index.ts#L138

The issue can be reproduced over here, run `yarn native ios -c`:
https://github.com/nandorojo/solito/tree/84ffea9675a86c9bbb2aad4c64b7454e49673dd7/example-monorepos/with-tailwind

The warning will be printed for `App.tsx` first.

Now,  I don't have any knowledge of the implementation of nativewind - and I may have ruined everything. Do let me know if there is anything to change. 