### PR TITLE
docs: fix typo in create-react-native quickstart

### DIFF
--- a/apps/website/docs/quick-starts/create-react-native-app.md
+++ b/apps/website/docs/quick-starts/create-react-native-app.md
@@ -23,7 +23,7 @@ yarn add --dev tailwindcss
 
 ## 2. Setup Tailwind CSS
 
-Run `npx tailwindcss init` to create a `tailwind.config.ts` file
+Run `npx tailwindcss init` to create a `tailwind.config.js` file
 
 Add the paths to all of your component files in your tailwind.config.js file.
 


### PR DESCRIPTION
Hi, thanks for creating this awesome project! I was trying out nativewind and found a little typo. 

In the create-react-native-app quickstart, instead of `tailwind.config.js`, `tailwind.config.ts` was written. I have fixed the typo in this pull request.