### PR TITLE
docs: fix typos in quickstarts

### DIFF
--- a/apps/website/docs/quick-starts/expo.md
+++ b/apps/website/docs/quick-starts/expo.md
@@ -27,7 +27,7 @@ yarn add --dev tailwindcss
 
 ## 2. Setup Tailwind CSS
 
-Run `npx tailwindcss init` to create a `tailwind.config.ts` file
+Run `npx tailwindcss init` to create a `tailwind.config.js` file
 
 Add the paths to all of your component files in your tailwind.config.js file. Remember to replace `<custom directory>` with the actual name of your directory e.g. `screens`.
 

--- a/apps/website/docs/quick-starts/ignite.md
+++ b/apps/website/docs/quick-starts/ignite.md
@@ -11,7 +11,7 @@ yarn add --dev tailwindcss
 
 ## 2. Setup Tailwind CSS
 
-Run `npx tailwindcss init` to create a `tailwind.config.ts` file
+Run `npx tailwindcss init` to create a `tailwind.config.js` file
 
 Add the paths to all of your component files in your tailwind.config.js file.
 

--- a/apps/website/docs/quick-starts/react-native-cli.md
+++ b/apps/website/docs/quick-starts/react-native-cli.md
@@ -18,7 +18,7 @@ yarn add --dev tailwindcss
 
 ## 2. Setup Tailwind CSS
 
-Run `npx tailwindcss init` to create a `tailwind.config.ts` file
+Run `npx tailwindcss init` to create a `tailwind.config.js` file
 
 Add the paths to all of your component files in your tailwind.config.js file.
 


### PR DESCRIPTION
In the expo, react-native-cli and ignite quickstart, instead of tailwind.config.js, tailwind.config.ts was written. I have fixed the typos in this pull request.