### PR TITLE
Removed Unused type alias PropertyGuard and aspectRatio fix

### DIFF
--- a/packages/nativewind/src/postcss/to-react-native/properties/aspect-ratio.ts
+++ b/packages/nativewind/src/postcss/to-react-native/properties/aspect-ratio.ts
@@ -4,7 +4,7 @@ import { PropertyFunction } from "./only";
 export const aspectRatio: PropertyFunction<"aspectRatio"> = (value) => {
   if (value === "0") {
     return {};
-  } else if (typeof value === "string" && value.includes("/")) {
+  } else if (value.includes("/")) {
     const [left, right] = value.split("/").map((n) => {
       return Number.parseInt(n, 10);
     });

--- a/packages/nativewind/src/postcss/to-react-native/properties/only.ts
+++ b/packages/nativewind/src/postcss/to-react-native/properties/only.ts
@@ -1,11 +1,6 @@
 import { getStylesForProperty, Style } from "css-to-react-native";
 import { ImageStyle, TextStyle, ViewStyle } from "react-native";
 
-export type PropertyGuard<T extends string> = (
-  value: string,
-  name: string
-) => PropertyFunction<T>;
-
 export interface PropertyFunction<T extends string> {
   prop?: T;
   (value: string, name: string): Style;


### PR DESCRIPTION

Changes:

`typeof value === "string" && value.includes("/")` has been optimised to  `value.includes("/")`. Because it's always string,  there is no point of checking typeOf.

- It looks like we are not using the PropertyGroup Type. So removed. 
 