### PR TITLE
add caution admonitions to make the warning / tip more easy to catch

### DIFF
--- a/apps/website/docs/guides/custom-components.mdx
+++ b/apps/website/docs/guides/custom-components.mdx
@@ -6,9 +6,13 @@ NativeWind's strength really shines with writing your own custom components.
 
 When passing styles between components, they are compiled on the parent and passed as a `style` prop to the child.
 
+:::caution
+ You need to use style, className is not passed down!
+:::
+
+
 ```tsx
 function MyComponent({ style }) {
-  // You need to use style, className is not passed down!
   return <Text style={style} />;
 }
 


### PR DESCRIPTION
hey @marklawlor I missed this one when passing style from parent to child so I think adding the notice above the code will make it more easier to note