### PR TITLE
Update custom-components documentation with Intellisense setup

### DIFF
--- a/apps/website/docs/guides/custom-components.mdx
+++ b/apps/website/docs/guides/custom-components.mdx
@@ -38,7 +38,7 @@ editor's language server configuration. The examples below enable autocompletion
 for class names with "Styles" in it. You can change this to accept whatever suits 
 your requirements.
 
-#### VS Code Example
+#### VS Code Example (`settings.json`)
 
 ```json
 "tailwindCSS.classAttributes": [".*Styles*"],

--- a/apps/website/docs/guides/custom-components.mdx
+++ b/apps/website/docs/guides/custom-components.mdx
@@ -31,6 +31,30 @@ function B({ textClassName }) {
 }
 ```
 
+### Intellisense for custom class names
+
+To get Intellisense (autocompletion) working for custom class names, update your 
+editor's language server configuration. The examples below enable autocompletion 
+for class names with "Styles" in it. You can change this to accept whatever suits 
+your requirements.
+
+#### VS Code Example
+
+```json
+"tailwindCSS.classAttributes": [".*Styles*"],
+```
+
+#### Neovim (lspconfig) Example
+```lua
+    tailwindcss = {
+      settings = {
+        tailwindCSS = {
+          classAttributes = { ".*Styles*" }
+        }
+      }
+    }
+```
+
 ## Merging styles
 
 NativeWind doesn't require you to merge or provide styles as an array. You can simply append the two classNames strings together

--- a/apps/website/docs/guides/custom-components.mdx
+++ b/apps/website/docs/guides/custom-components.mdx
@@ -46,13 +46,13 @@ your requirements.
 
 #### Neovim (lspconfig) Example
 ```lua
-    tailwindcss = {
-      settings = {
-        tailwindCSS = {
-          classAttributes = { ".*Styles*" }
-        }
-      }
+tailwindcss = {
+  settings = {
+    tailwindCSS = {
+      classAttributes = { ".*Styles*" }
     }
+  }
+}
 ```
 
 ## Merging styles


### PR DESCRIPTION
I had trouble figuring out how to get autocompletion working for custom classNames as shown in the examples. Added a section describing how to update your language server configurations to get it working.