### PR TITLE
Fix typo expo.md

### DIFF
--- a/apps/website/docs/quick-starts/expo.md
+++ b/apps/website/docs/quick-starts/expo.md
@@ -93,7 +93,7 @@ module.exports = function (api) {
 ## 6. Enable CSS Support in Expo's Metro Config
 
 ```js
-// metro.confgi.js
+// metro.config.js
 const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname, {


### PR DESCRIPTION
I'm pretty sure, it shoul say `config` and not `confgi`