### PR TITLE
V4: Fix to missing react-native-css-interop-env/types reference + another small tweak

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:nativewind": "npm run test --workspace=nativewind --",
     "test:css": "npm run test --workspace=react-native-css-interop --",
     "build": "npm run build --workspace=nativewind --",
-    "example": "npm start --workspace=example --",
+    "example": "npm start --workspace=examples/test --",
     "clean": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && rm package-lock.json && npm i"
   },
   "devDependencies": {

--- a/packages/nativewind/types.d.ts
+++ b/packages/nativewind/types.d.ts
@@ -1,1 +1,1 @@
-/// <ref types="react-native-css-interop-env/types"
+/// <reference types="react-native-css-interop/types" />

--- a/packages/react-native-css-interop/package.json
+++ b/packages/react-native-css-interop/package.json
@@ -43,7 +43,7 @@
     "jsx-runtime/",
     "metro/",
     "testing-library/",
-    "react-native-css-interop-env.d.ts"
+    "types.d.ts"
   ],
   "dependencies": {
     "lightningcss": "^1.21.5"


### PR DESCRIPTION
I setup v4 on a personal project and could not get my CI to successfully pass because he could not find this file `react-native-css-interop-env/types`:

<img width="813" alt="Screenshot 2023-08-05 at 7 43 37 pm" src="https://github.com/marklawlor/nativewind/assets/21725/288394ee-b57c-48a6-9df3-cfff70e35f15">

+ a small tweak to the main package test app script