### PR TITLE
[v3]  Web variable subscription callbacks are running before html style update

### DIFF
--- a/packages/nativewind/src/runtime/web/stylesheet/runtime.ts
+++ b/packages/nativewind/src/runtime/web/stylesheet/runtime.ts
@@ -13,16 +13,16 @@ export function getSSRStyles() {
 
 export function setVariables(properties: Record<`--${string}`, VariableValue>) {
   for (const [name, value] of Object.entries(properties)) {
-    // eslint-disable-next-line unicorn/no-array-for-each
-    variableSubscriptions.get(name)?.forEach((callback) => {
-      callback();
-    });
-
     variables.set(name, value);
 
     if (typeof window !== "undefined") {
       window.document.documentElement.style.setProperty(name, value.toString());
     }
+
+    // eslint-disable-next-line unicorn/no-array-for-each
+    variableSubscriptions.get(name)?.forEach((callback) => {
+      callback();
+    });
   }
 }
 


### PR DESCRIPTION
My "useUnsafeVariables" always returns empty string  on web and I get the real value after the next re-render. After some debugging I found the reason - callbacks are running before the html tag style update.
The fix is pretty simple and matches the native implementation which works perfectly.

@marklawlor  I know you're busy with expo, but hope this one won't disturb you much.