### PR TITLE
fix doc V4 - tailwindcss config presets 

### DIFF
--- a/apps/website/docs/getting-started/expo-router.mdx
+++ b/apps/website/docs/getting-started/expo-router.mdx
@@ -23,7 +23,7 @@ Add the paths to all of your component files in your tailwind.config.js file.
 module.exports = {
 - content: [],
 + content: ["./app/**/*.{js,jsx,ts,tsx}", "./<custom-folder>/**/*.{js,jsx,ts,tsx}"],
-+ preset: [require("nativewind/preset")],
++ presets: [require("nativewind/preset")],
   theme: {
     extend: {},
   },

--- a/apps/website/docs/getting-started/metro.mdx
+++ b/apps/website/docs/getting-started/metro.mdx
@@ -31,7 +31,7 @@ Add the paths to all of your component files in your tailwind.config.js file.
 module.exports = {
 - content: [],
 + content: ["./App.{js,jsx,ts,tsx}", "./<custom-folder>/**/*.{js,jsx,ts,tsx}"],
-+ preset: [require("nativewind/preset")],
++ presets: [require("nativewind/preset")],
   theme: {
     extend: {},
   },

--- a/apps/website/src/pages/v4/troubleshooting.mdx
+++ b/apps/website/src/pages/v4/troubleshooting.mdx
@@ -75,7 +75,7 @@ NativeWind was able to detect and parse a CSS file, but the file parsed did not 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["<content>"],
-  preset: [require("nativewind/preset")],
+  presets: [require("nativewind/preset")],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
When checking the [documentation](https://www.nativewind.dev/v4/getting-started/metro) to configure my test project using nativewind V4, I noticed that in the TailwindCSS configuration section, it is showing to add the **preset** and not **presets**, according to the [tailwindcss documentation](https://tailwindcss.com/docs/presets)