### PR TITLE
Add pod-install instruction

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -6,3 +6,9 @@ You will need to install `nativewind@^4.0.1` and it's peer dependencies `tailwin
   deps={["nativewind@^4.0.1", "react-native-reanimated"]}
   devDeps={["tailwindcss"]}
 />
+
+Run `pod-install` to install Reanimated pod:
+
+```bash
+npx pod-install
+```


### PR DESCRIPTION
Running the guide to install NativeWind v4 in my React Native project, I encountered an issue.
![Simulator Screenshot - iPhone 15 - 2023-11-10 at 14 16 10](https://github.com/marklawlor/nativewind/assets/6640360/f83205c8-c79f-4a5e-874d-db488cb6ebd9)

This was right after installing the dependencies. I noticed that it's necessary to run a pod install to install the Reanimated pod, as mentioned in the docs: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#ios.

So I propose this change in the React Native guide, including the instruction to run pod install right after installing the dependencies.

