### PR TITLE
[v4] Add missed colorScheme export

### DIFF
--- a/packages/nativewind/src/index.tsx
+++ b/packages/nativewind/src/index.tsx
@@ -8,6 +8,7 @@ export {
   cssInterop,
   remapProps,
   StyleSheet,
+  colorScheme,
   rem,
 } from "react-native-css-interop";
 


### PR DESCRIPTION
I am trying to test the new NativeWind version, and while reading the new docs, it looks like we can set the color scheme manually using `colorScheme.set(value)` As mentioned in the docs [here](https://www.nativewind.dev/v4/core-concepts/dark-mode#manual-color-scheme-control).

But apparently, the `colorScheme` export has been forgotten. This PR is simply to fix that.