### PR TITLE
update installation docs

### DIFF
--- a/apps/website/docs/getting-started/_install.mdx
+++ b/apps/website/docs/getting-started/_install.mdx
@@ -3,8 +3,7 @@ import NPM from "../_npm.mdx";
 You will need to install `nativewind@^4.0.1` and it's peer dependencies `tailwindcss` and `react-native-reanimated`.
 
 <NPM
-  deps={["nativewind@^4.0.1", "react-native-reanimated"]}
-  devDeps={["tailwindcss"]}
+  deps={["nativewind@^4.0.1", "react-native-reanimated", "tailwindcss"]}
 />
 
 Run `pod-install` to install Reanimated pod:

--- a/apps/website/docs/getting-started/_tailwind.mdx
+++ b/apps/website/docs/getting-started/_tailwind.mdx
@@ -2,12 +2,12 @@ Run `npx tailwindcss init` to create a `tailwind.config.js` file
 
 Add the paths to all of your component files in your tailwind.config.js file.
 
-```diff title="tailwind.config.js"
+```js title="tailwind.config.js"
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-- content: [],
-+ content: ["./<custom-folder>/**/*.{js,jsx,ts,tsx}"],
-+ presets: [require("nativewind/preset")],
+  // NOTE: Update this to include the paths to all of your component files.
+  content: ["./app/**/*.{js,jsx,ts,tsx}"],
+  presets: [require("nativewind/preset")],
   theme: {
     extend: {},
   },
@@ -25,6 +25,6 @@ Create a CSS file and add the Tailwind directives
 
 :::info
 
-From here onwards, replace `./your-css-file.css` with the relative path to the CSS file you just created
+From here onwards, replace `./global.css` with the relative path to the CSS file you just created
 
 :::

--- a/apps/website/docs/getting-started/expo-router.mdx
+++ b/apps/website/docs/getting-started/expo-router.mdx
@@ -17,20 +17,40 @@ import Tailwind from "./_tailwind.mdx";
 
 ### 3. Add the Babel preset
 
-```diff title="babel.config.js"
-module.exports = {
-- presets: ['babel-preset-expo'],
-+ presets: [
-+   ["babel-preset-expo", { jsxImportSource: "nativewind" }],
-+   "nativewind/babel",
-+ ],
-  plugins: [
-    // Required for expo-router
-    "expo-router/babel",
-    "react-native-reanimated/plugin",
-  ],
-};
-```
+<Tabs>
+  <TabItem value="SDK 49">
+    ```js title="babel.config.js"
+    module.exports = function (api) {
+      api.cache(true);
+      return {
+        presets: [
+          ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+          "nativewind/babel",
+        ],
+        plugins: [
+          // Required for expo-router
+          "expo-router/babel",
+          "react-native-reanimated/plugin",
+        ]
+      };
+    };
+    ```
+  </TabItem>
+  <TabItem value="SDK 50+">
+    ```js title="babel.config.js"
+    module.exports = function (api) {
+      api.cache(true);
+      return {
+        presets: [
+          ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+          "nativewind/babel",
+        ],
+      };
+    };
+    ```
+  </TabItem>
+</Tabs>
+
 
 ### 4. Modify your metro.config.js
 
@@ -39,39 +59,38 @@ If your project does not have a `metro.config.js` run `npx expo customize metro.
 <Tabs>
 <TabItem value="SDK 49">
 
-```diff title="metro.config.js"
+```js title="metro.config.js"
 const { getDefaultConfig } = require("expo/metro-config");
-+ const { withNativeWind } = require('nativewind/metro');
+const { withNativeWind } = require('nativewind/metro');
 
-- const config = getDefaultConfig(__dirname)
-+ const config = getDefaultConfig(__dirname, { isCSSEnabled: true })
+const config = getDefaultConfig(__dirname, { isCSSEnabled: true })
 
-- module.exports = config
-+ module.exports = withNativeWind(config, { input: './your-css-file.css' })
+module.exports = withNativeWind(config, { input: './global.css' })
 ```
 
 </TabItem>
 <TabItem value="SDK 50+">
 
-```diff title="metro.config.js"
+```js title="metro.config.js"
 const { getDefaultConfig } = require("expo/metro-config");
-+ const { withNativeWind } = require('nativewind/metro');
+const { withNativeWind } = require('nativewind/metro');
 
 const config = getDefaultConfig(__dirname)
 
-- module.exports = config
-+ module.exports = withNativeWind(config, { input: './your-css-file.css' })
+module.exports = withNativeWind(config, { input: './global.css' })
 ```
 
-</TabItem >
+</TabItem>
 
 </Tabs>
 
 ### 5. Import your CSS file
 
-```diff title="app/_layout.js"
+```js title="app/_layout.js"
 import Slot from "expo-router/Slot";
-+ import "./<your-css-file>.css"
+
+// Import your global CSS file
+import "../global.css"
 
 export default Slot
 

--- a/apps/website/docs/getting-started/react-native.mdx
+++ b/apps/website/docs/getting-started/react-native.mdx
@@ -26,19 +26,38 @@ NativeWind works with both Expo and Vanilla React Native projects but Expo provi
 ### 3. Add the Babel preset
 
 <Tabs groupId="framework">
-  <TabItem value="expo" label="Expo">
+  <TabItem value="Expo SDK 49">
+    ```js title="babel.config.js"
+    module.exports = function (api) {
+      api.cache(true);
+      return {
+        presets: [
+          ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+          "nativewind/babel",
+        ],
+        plugins: [
+          // Required for expo-router
+          "expo-router/babel",
+          "react-native-reanimated/plugin",
+        ]
+      };
+    };
+    ```
+  </TabItem>
+  <TabItem value="Expo SDK 50+">
+    ```js title="babel.config.js"
+    module.exports = function (api) {
+      api.cache(true);
+      return {
+        presets: [
+          ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+          "nativewind/babel",
+        ],
+      };
+    };
+    ```
+  </TabItem>
 
-```diff title="babel.config.js"
-module.exports = {
-- presets: ['babel-preset-expo'],
-+ presets: [
-+   ["babel-preset-expo", { jsxImportSource: "nativewind" }],
-+   "nativewind/babel",
-+ ],
-};
-```
-
-</TabItem>
 <TabItem value="vanilla" label="Vanilla">
 
 ```diff title="babel.config.js"
@@ -58,27 +77,24 @@ module.exports = {
     <Tabs groupId="sdk">
       <TabItem value="Expo SDK 49">
 
-        ```diff title="metro.config.js"
+        ```js title="metro.config.js"
         const { getDefaultConfig } = require("expo/metro-config");
-        + const { withNativeWind } = require('nativewind/metro');
+        const { withNativeWind } = require('nativewind/metro');
 
-        - const config = getDefaultConfig(__dirname)
-        + const config = getDefaultConfig(__dirname, { isCSSEnabled: true })
+        const config = getDefaultConfig(__dirname, { isCSSEnabled: true })
 
-        - module.exports = config
-        + module.exports = withNativeWind(config, { input: './your-css-file.css' })
+        module.exports = withNativeWind(config, { input: './global.css' })
         ```
       </TabItem>
       <TabItem value="Expo SDK 50">
 
-        ```diff title="metro.config.js"
+        ```js title="metro.config.js"
         const { getDefaultConfig } = require("expo/metro-config");
-        + const { withNativeWind } = require('nativewind/metro');
+        const { withNativeWind } = require('nativewind/metro');
 
         const config = getDefaultConfig(__dirname)
 
-        - module.exports = config
-        + module.exports = withNativeWind(config, { input: './your-css-file.css' })
+        module.exports = withNativeWind(config, { input: './global.css' })
         ```
 
         </TabItem >
@@ -88,13 +104,12 @@ module.exports = {
 
   <TabItem value="vanilla" label="Vanilla">
 
-```diff title="metro.config.js"
-+ const { withNativeWind } = require('nativewind/metro')
+```js title="metro.config.js"
+const { withNativeWind } = require('nativewind/metro')
 
 const config = {/* your config */}
 
-- module.exports = config
-+ module.exports = withNativeWind(config, { input: './your-css-file.css'})
+module.exports = withNativeWind(config, { input: './global.css'})
 ```
 
   </TabItem>
@@ -102,8 +117,8 @@ const config = {/* your config */}
 
 ### 5. Import your CSS file
 
-```diff title="App.js"
-+ import "./<your-css-file>.css"
+```js title="App.js"
+import "./global.css"
 
 export default App() {
   /* Your App */

--- a/apps/website/docs/getting-started/react-native.mdx
+++ b/apps/website/docs/getting-started/react-native.mdx
@@ -57,9 +57,8 @@ NativeWind works with both Expo and framework-less React Native projects but Exp
     };
     ```
   </TabItem>
-</TabItem>
 
-<TabItem value="framework-less" label="Framework-less">
+  <TabItem value="framework-less" label="Framework-less">
 
 ```diff title="babel.config.js"
 module.exports = {
@@ -68,40 +67,36 @@ module.exports = {
 };
 ```
 
-</TabItem>
+  </TabItem>
 </Tabs>
 
 ### 4. Modify your metro.config.js
 
 <Tabs groupId="framework">
-  <TabItem value="Expo">
-    <Tabs groupId="sdk">
-      <TabItem value="Expo SDK 49">
+  <TabItem value="Expo SDK 49">
 
-        ```js title="metro.config.js"
-        const { getDefaultConfig } = require("expo/metro-config");
-        const { withNativeWind } = require('nativewind/metro');
+    ```js title="metro.config.js"
+    const { getDefaultConfig } = require("expo/metro-config");
+    const { withNativeWind } = require('nativewind/metro');
 
-        const config = getDefaultConfig(__dirname, { isCSSEnabled: true })
+    const config = getDefaultConfig(__dirname, { isCSSEnabled: true })
 
-        module.exports = withNativeWind(config, { input: './global.css' })
-        ```
-      </TabItem>
-      <TabItem value="Expo SDK 50">
-
-        ```js title="metro.config.js"
-        const { getDefaultConfig } = require("expo/metro-config");
-        const { withNativeWind } = require('nativewind/metro');
-
-        const config = getDefaultConfig(__dirname)
-
-        module.exports = withNativeWind(config, { input: './global.css' })
-        ```
-
-        </TabItem >
-    </Tabs>
-
+    module.exports = withNativeWind(config, { input: './global.css' })
+    ```
   </TabItem>
+  <TabItem value="Expo SDK 50+">
+
+    ```js title="metro.config.js"
+    const { getDefaultConfig } = require("expo/metro-config");
+    const { withNativeWind } = require('nativewind/metro');
+
+    const config = getDefaultConfig(__dirname)
+
+    module.exports = withNativeWind(config, { input: './global.css' })
+    ```
+
+  </TabItem >
+
 
   <TabItem value="frameworkless" label="Framework-less">
 


### PR DESCRIPTION
- The diff blocks make it harder to copy/paste as you need to go back and remove the `+` and `-` characters. In most cases there is no file to diff, e.g. `tailwind.config.js` file won't exist in a React Native project until I add this library. In other cases it seems like users will be familiar enough with the modifications they added manually to diff themselves.
- Using dev deps for `tailwindcss`  is not necessary and causes issues with eas build where production installs will skip dev deps. I've moved this to the standard dependencies installation.
- `your-css-file.css` is needlessly abstract. Most users are probably just going to want the standard tailwind setup, which uses `global.css`. This allows for more copy/paste.
- Added SDK 50 babel instructions and align with the upstream config.

Would be nice to cover the postcss option too so we have a single guide that looks identical to standard tailwind guides, but I don't think this is supported on native at the moment so I'm skipping it here.