### PR TITLE
change vanilla label to "framework-less"

### DIFF
--- a/apps/website/docs/getting-started/nextjs.mdx
+++ b/apps/website/docs/getting-started/nextjs.mdx
@@ -3,7 +3,7 @@ import TabItem from "@theme/TabItem";
 
 # Next.js
 
-NativeWind can be used in a Next.js project that is already configured to use Expo or vanilla React Native Web.
+NativeWind can be used in a Next.js project that is already configured to use Expo or framework-less React Native Web.
 
 Setting up a new Next.js project to use React Native Web is out of scope for these instructions.
 

--- a/apps/website/docs/getting-started/react-native.mdx
+++ b/apps/website/docs/getting-started/react-native.mdx
@@ -7,7 +7,7 @@ import Tailwind from "./_tailwind.mdx";
 
 :::info
 
-NativeWind works with both Expo and Vanilla React Native projects but Expo provides a more streamlined experience.
+NativeWind works with both Expo and framework-less React Native projects but Expo provides a more streamlined experience.
 
 **Web**: If you wish to use Metro to bundle for website or App Clip and you are **not** using Expo, you will need either: Expo's Metro config `@expo/metro-config` or manually use Tailwind CLI to generate a CSS file.
 
@@ -39,7 +39,7 @@ module.exports = {
 ```
 
 </TabItem>
-<TabItem value="vanilla" label="Vanilla">
+<TabItem value="framework-less" label="Framework-less">
 
 ```diff title="babel.config.js"
 module.exports = {
@@ -86,7 +86,7 @@ module.exports = {
 
   </TabItem>
 
-  <TabItem value="vanilla" label="Vanilla">
+  <TabItem value="frameworkless" label="Framework-less">
 
 ```diff title="metro.config.js"
 + const { withNativeWind } = require('nativewind/metro')

--- a/apps/website/versioned_docs/version-v2/guides/universal-system.md
+++ b/apps/website/versioned_docs/version-v2/guides/universal-system.md
@@ -10,7 +10,7 @@ Every library needs to solve a core problem
 
 ```tsx
 /*
-  This is a vanilla React Native component that changes backgroundColor based upon
+  This is a framework-less React Native component that changes backgroundColor based upon
   - UI State
   - Color scheme
   - Branding
@@ -50,7 +50,7 @@ export function MyButton(props) {
 }
 ```
 
-You may argue that the vanilla example isn't that complex, but this is _basic example_ with only 1 component and 4 states. As you add more UI states (focus, hover) the vanilla example will grow in complexity. As your project grows you will also need more features like overriding single styles or styling based upon a different components state.
+You may argue that the standard example isn't that complex, but this is _basic example_ with only 1 component and 4 states. As you add more UI states (focus, hover) the basic example will grow in complexity. As your project grows you will also need more features like overriding single styles or styling based upon a different components state.
 
 NativeWind solves the state issues for you and allows you to simply focus on your components appearance. If you need to extends or override a components styles, its as simple as passing the className prop.
 

--- a/apps/website/versioned_docs/version-v2/quick-starts/nextjs.md
+++ b/apps/website/versioned_docs/version-v2/quick-starts/nextjs.md
@@ -1,6 +1,6 @@
 # Next.js
 
-NativeWind can be used in a Next.js project that is already configured to use Expo or vanilla React Native Web.
+NativeWind can be used in a Next.js project that is already configured to use Expo or framework-less React Native Web.
 
 ## 1. Setup Tailwind CSS
 


### PR DESCRIPTION
This labeling aligns a bit more closely with how things are named in the React docs https://react.dev/learn/start-a-new-react-project where the recommended flow is a framework and the alternative is no framework.