### PR TITLE
fix(docs):"npm start" error

### DIFF
--- a/apps/website/docs/getting-started/react-native.mdx
+++ b/apps/website/docs/getting-started/react-native.mdx
@@ -106,7 +106,6 @@ const { withNativeWind } = require('nativewind/metro')
 
 const config = mergeConfig(getDefaultConfig(__dirname), {
   /* your config */
-  isCSSEnabled: true,
 });
 
 module.exports = withNativeWind(config, { input: './global.css'})

--- a/apps/website/docs/getting-started/react-native.mdx
+++ b/apps/website/docs/getting-started/react-native.mdx
@@ -101,9 +101,13 @@ module.exports = {
   <TabItem value="frameworkless" label="Framework-less">
 
 ```js title="metro.config.js"
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const { withNativeWind } = require('nativewind/metro')
 
-const config = {/* your config */}
+const config = mergeConfig(getDefaultConfig(__dirname), {
+  /* your config */
+  isCSSEnabled: true,
+});
 
 module.exports = withNativeWind(config, { input: './global.css'})
 ```


### PR DESCRIPTION
Getting Started - React Native-Modify your metro.config.js
npm start Error
error Cannot read properties of undefined (reading 'sourceExts').