### PR TITLE
Fix: Missing spread operator for children  in createElementAndCheckCs…

### DIFF
--- a/packages/react-native-css-interop/src/runtime/components/rendering.native.ts
+++ b/packages/react-native-css-interop/src/runtime/components/rendering.native.ts
@@ -102,7 +102,7 @@ export const cssInterop: CssInterop = (component, mapping) => {
       if (props && props.children) {
         children = props.children;
       }
-      return defaultCSSInterop(component, config, props, children);
+      return defaultCSSInterop(component, config, props, ...children);
     },
     check(props: Record<string, unknown> | null) {
       if (props === null) return false;

--- a/packages/react-native-css-interop/src/runtime/components/rendering.native.ts
+++ b/packages/react-native-css-interop/src/runtime/components/rendering.native.ts
@@ -201,7 +201,7 @@ export function createElementAndCheckCssInterop(
 
   return !interop || !interop.check(props)
     ? createElement(type, props, ...children)
-    : interop.createElement(props, children);
+    : interop.createElement(props, ...children);
 }
 
 function getNormalizeConfig(

--- a/packages/react-native-css-interop/src/runtime/native/interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/interop.ts
@@ -22,7 +22,7 @@ export const defaultCSSInterop: InteropFunction = (
   component,
   options,
   originalProps,
-  children,
+  ...children
 ) => {
   let props: Record<string, any> = originalProps
     ? { ...originalProps, children }
@@ -83,12 +83,12 @@ export const defaultCSSInterop: InteropFunction = (
   }
 
   if (state.context) {
-    children = createElement(component, props, children);
+    children = [createElement(component, props, ...children)];
     props = { value: state.context };
     component = InteropProvider;
   }
 
-  return createElement(component, props, children);
+  return createElement(component, props, ...children);
 };
 
 /**

--- a/packages/react-native-css-interop/src/types.ts
+++ b/packages/react-native-css-interop/src/types.ts
@@ -185,7 +185,7 @@ export type InteropFunction = (
   type: any,
   options: NormalizedOptions,
   props: Record<string, any> | null,
-  children: ReactNode,
+  ...children: ReactNode[]
 ) => ReactElement;
 
 export type InteropFunctionOptions<P> = {


### PR DESCRIPTION
…sInterop resulted in warning: Each child in the list should have a unique "key" attribute.