### PR TITLE
fix: tailwind-cli ws server default port conflicts with flipper default port, both use 8089

### DIFF
--- a/packages/nativewind/src/metro/tailwind-cli.ts
+++ b/packages/nativewind/src/metro/tailwind-cli.ts
@@ -170,7 +170,7 @@ export async function tailwindCli(
     });
 }
 
-async function getAvailablePort(port = 8089): Promise<number> {
+async function getAvailablePort(port = 8082): Promise<number> {
   return checkAvailablePort(port).catch(() => getAvailablePort(port + 1));
 }
 

--- a/packages/react-native-css-interop/src/metro/expo.ts
+++ b/packages/react-native-css-interop/src/metro/expo.ts
@@ -14,6 +14,7 @@ export function expoColorSchemeWarning() {
 
 function isExpo() {
   try {
+    require("expo");
     require("@expo/config");
     return true;
   } catch {


### PR DESCRIPTION
![1706111941459](https://github.com/marklawlor/nativewind/assets/20939091/06777019-9300-440f-8425-caf7e877a41d)
1.Flipper is a commonly used debugger tool. If we still have a choice, try not to use the same port
2.Optimization: isExpo method, only judging @expo/config is not good enough