### PR TITLE
fix onPress bug

### DIFF
--- a/packages/react-native-css-interop/src/runtime/native/interop.ts
+++ b/packages/react-native-css-interop/src/runtime/native/interop.ts
@@ -59,8 +59,8 @@ export const defaultCSSInterop: InteropFunction = (
 
   // Merge the styled props with the props passed to the component
   props = {
-    ...props,
     ...state.props,
+    ...props,
   };
 
   // Delete any props that were used as sources


### PR DESCRIPTION
fix for that issue:
https://github.com/marklawlor/nativewind/issues/770 when you have some callback and some state with the callback
```
const [counter, setCounter] = useState(0)
...


<Pressable 
    className="active:bg-red-500"
    onPress={()=> console.log(counter)}
/> 
<Text> Press me
</Pressable>l
...
```

the counter will show only the initial value