### PR TITLE
docs: update expo quick start with compatible tailwindcss version

### DIFF
--- a/apps/website/docs/quick-starts/expo.md
+++ b/apps/website/docs/quick-starts/expo.md
@@ -22,8 +22,14 @@ You will need to install `nativewind` and it's peer dependency `tailwindcss`.
 
 ```bash
 yarn add nativewind
-yarn add --dev tailwindcss
+yarn add --dev tailwindcss@3.3.2
 ```
+
+:::warning
+
+ Make sure to install `tailwindcss` v3.3.2 as newer versions aren't compatible with `nativewind`. For more information follow this [discussion](https://github.com/marklawlor/nativewind/issues/498).
+
+:::
 
 ## 2. Setup Tailwind CSS
 


### PR DESCRIPTION
### Goal
At the moment when following the [Expo quick start guide](https://www.nativewind.dev/quick-starts/expo) users might stumble upon an error due to an incompatible `tailwindcss` version.

This issue relates to this issue #498 where users receive this error
```
Error: Use process(css).then(cb) to work with async plugins
```
### Implementation
Edit documentation by prompting the user to install the latest `tailwindcss` compatible version v3.3.2 and adding a warning

