### PR TITLE
[V4] Ignore className if empty string is provided

### DIFF
--- a/.changeset/soft-poets-cheat.md
+++ b/.changeset/soft-poets-cheat.md
@@ -1,0 +1,6 @@
+---
+"react-native-css-interop": patch
+"nativewind": patch
+---
+
+skip empty-classNames

--- a/packages/react-native-css-interop/src/__tests__/sanity-checks.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/sanity-checks.test.tsx
@@ -49,11 +49,13 @@ test("empty className", () => {
     testID,
   );
 
+  expect(component.props.className).not.toBeDefined();
   expect(component).toHaveStyle(undefined);
 });
 
 test("missing className", () => {
   const component = render(<A testID={testID} />).getByTestId(testID);
 
-  expect(component).toHaveStyle(undefined);
+  expect(component.props.className).not.toBeDefined();
+  expect(component.props.style).not.toBeDefined();
 });

--- a/packages/react-native-css-interop/src/__tests__/sanity-checks.test.tsx
+++ b/packages/react-native-css-interop/src/__tests__/sanity-checks.test.tsx
@@ -43,3 +43,17 @@ test("dynamic variables should not unmount children", () => {
   expect(onUnMount).not.toHaveBeenCalled();
   expect(onMount).toHaveBeenCalledTimes(1);
 });
+
+test("empty className", () => {
+  const component = render(<A testID={testID} className="" />).getByTestId(
+    testID,
+  );
+
+  expect(component).toHaveStyle(undefined);
+});
+
+test("missing className", () => {
+  const component = render(<A testID={testID} />).getByTestId(testID);
+
+  expect(component).toHaveStyle(undefined);
+});

--- a/packages/react-native-css-interop/src/runtime/native/api.ts
+++ b/packages/react-native-css-interop/src/runtime/native/api.ts
@@ -67,7 +67,7 @@ export const remapProps: CssInterop = (component: any, mapping): any => {
 
       const source = props?.[config.source];
 
-      if (typeof source !== "string") continue;
+      if (typeof source !== "string" || !source) continue;
       delete props[config.source];
 
       for (const className of source.split(/\s+/)) {

--- a/packages/react-native-css-interop/src/runtime/native/api.ts
+++ b/packages/react-native-css-interop/src/runtime/native/api.ts
@@ -67,7 +67,9 @@ export const remapProps: CssInterop = (component: any, mapping): any => {
 
       const source = props?.[config.source];
 
+      // If the source is not a string or is empty, skip this config
       if (typeof source !== "string" || !source) continue;
+
       delete props[config.source];
 
       for (const className of source.split(/\s+/)) {

--- a/packages/react-native-css-interop/src/runtime/web/api.ts
+++ b/packages/react-native-css-interop/src/runtime/web/api.ts
@@ -38,6 +38,7 @@ export const cssInterop: CssInterop = (baseComponent, mapping): any => {
       const source = props[config.source];
       const target: StyleProp = props[config.target];
 
+      // Ensure we only add non-empty strings
       if (typeof source === "string" && source) {
         newStyles.push({
           $$css: true,

--- a/packages/react-native-css-interop/src/runtime/web/api.ts
+++ b/packages/react-native-css-interop/src/runtime/web/api.ts
@@ -38,7 +38,7 @@ export const cssInterop: CssInterop = (baseComponent, mapping): any => {
       const source = props[config.source];
       const target: StyleProp = props[config.target];
 
-      if (typeof source === "string") {
+      if (typeof source === "string" && source) {
         newStyles.push({
           $$css: true,
           [source]: source,


### PR DESCRIPTION
fixes #650 for components using tailwind-merge which returns an empty string instead on undefined

<img width="635" alt="image" src="https://github.com/marklawlor/nativewind/assets/40897161/5ef98235-a6e3-46d8-bf05-8922a5e97a92">
