### PR TITLE
[docs] Fix typos

### DIFF
--- a/apps/website/docs/customization/colors.md
+++ b/apps/website/docs/customization/colors.md
@@ -4,7 +4,7 @@ You can customize your colors in the same manner as Tailwind CSS. Please refer t
 
 ## Platform Colors
 
-Unlike the web, which uses a common color palette, native platforms have their own unique system colors which as access through [PlatformColor](https://reactnative.dev/docs/platformcolor)
+Unlike the web, which uses a common color palette, native platforms have their own unique system colors which are accessible through [PlatformColor](https://reactnative.dev/docs/platformcolor).
 
 NativeWind allows you to use access PlatformColor via the `platformColor()` utility.
 

--- a/apps/website/docs/customization/configuration.md
+++ b/apps/website/docs/customization/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-NativeWind uses the same `tailwind.config.js` as Tailwind CSS. You can read more about how to configure your project [through the Tailwind CSS documentation](https://tailwindcss.com/docs/configuration)
+NativeWind uses the same `tailwind.config.js` as Tailwind CSS. You can read more about how to configure your project [through the Tailwind CSS documentation](https://tailwindcss.com/docs/configuration).
 
 ## Metro configuration
 

--- a/apps/website/docs/customization/theme.md
+++ b/apps/website/docs/customization/theme.md
@@ -6,7 +6,7 @@ Fully dynamic React Native applications often make use of helper functions such 
 
 ## platformSelect
 
-platformSelect is the equivalent to (`Platform.select()`)[https://reactnative.dev/docs/platform#select]
+`platformSelect` is the equivalent to (`Platform.select()`)[https://reactnative.dev/docs/platform#select].
 
 ```js
 // tailwind.config.js
@@ -51,7 +51,7 @@ module.exports = {
 
 ### hairlineWidth()
 
-Equivalent of ()`StyleSheet.hairlineWidth`)[https://reactnative.dev/docs/stylesheet#hairlinewidth]
+Equivalent of (`StyleSheet.hairlineWidth`)[https://reactnative.dev/docs/stylesheet#hairlinewidth]
 
 ```ts title=tailwind.config.js
 const { hairlineWidth } = require("nativewind/theme");


### PR DESCRIPTION
## Why

Found some grammatical issues and typos while going through some of the pages in the docs. This PR is an attempt to fix them.

## Test plan

Tested them locally by running `yarn build`, `cd build/`, and then `npm run server`.