### PR TITLE
Export useSafeAreaEnv from react-native-css-interop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,17 +44,17 @@
       }
     },
     "apps/website": {
-      "version": "0.0.35",
+      "version": "0.0.38",
       "dependencies": {
         "@docusaurus/core": "3.0.0",
         "@docusaurus/preset-classic": "3.0.0",
         "@mdx-js/react": "3.0.0",
         "@types/lodash.debounce": "4.0.8",
         "docusaurus-plugin-sass": "0.2.5",
-        "nativewind": "4.0.33",
+        "nativewind": "4.0.36",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-native-css-interop": "0.0.33",
+        "react-native-css-interop": "0.0.36",
         "react-twitter-embed": "4.0.4",
         "sass": "1.69.5",
         "tailwindcss": "3.4.1"
@@ -62,7 +62,7 @@
     },
     "examples/expo-router": {
       "name": "nativewind-expo-router",
-      "version": "1.0.35",
+      "version": "1.0.38",
       "dependencies": {
         "@changesets/cli": "^2.26.2",
         "@expo/vector-icons": "^14.0.0",
@@ -76,7 +76,7 @@
         "expo-status-bar": "~1.11.1",
         "expo-system-ui": "~2.9.0",
         "expo-web-browser": "~12.8.2",
-        "nativewind": "4.0.33",
+        "nativewind": "4.0.36",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.73.2",
@@ -32950,10 +32950,10 @@
       }
     },
     "packages/nativewind": {
-      "version": "4.0.33",
+      "version": "4.0.36",
       "license": "MIT",
       "dependencies": {
-        "react-native-css-interop": "0.0.33"
+        "react-native-css-interop": "0.0.36"
       },
       "devDependencies": {
         "@tailwindcss/container-queries": "^0.1.1",
@@ -32972,7 +32972,7 @@
       }
     },
     "packages/react-native-css-interop": {
-      "version": "0.0.33",
+      "version": "0.0.36",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
@@ -32993,7 +32993,7 @@
         "react-native-reanimated": "~3.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
         "react": ">=18",

--- a/packages/nativewind/src/index.tsx
+++ b/packages/nativewind/src/index.tsx
@@ -3,6 +3,7 @@ export { verifyInstallation } from "./doctor";
 export {
   createElement,
   useUnstableNativeVariable,
+  useSafeAreaEnv,
   vars,
   cssInterop,
   remapProps,

--- a/packages/react-native-css-interop/src/index.ts
+++ b/packages/react-native-css-interop/src/index.ts
@@ -9,6 +9,7 @@ export {
   StyleSheet,
   colorScheme,
   useColorScheme,
+  useSafeAreaEnv,
   useUnstableNativeVariable,
   vars,
   rem,


### PR DESCRIPTION
The [docs mention](https://github.com/marklawlor/nativewind/blob/4acc98867e1a4a30f5ee0c24f717711cbebfc78e/apps/website/docs/tailwind/new-concepts/safe-area-insets.mdx) using `useSafeAreEnv`, but it's not actually exported from `nativewind`. 

This PR exports them from `react-native-css-interop`, and then from `nativewind`. 