### PR TITLE
[v4] batch effects

### DIFF
--- a/packages/react-native-css-interop/src/runtime/observable.ts
+++ b/packages/react-native-css-interop/src/runtime/observable.ts
@@ -1,3 +1,4 @@
+import { unstable_batchedUpdates } from 'react-native';
 /**
  * Observer pattern implementation
  *
@@ -50,9 +51,11 @@ export function observable<T>(
       value = newValue;
       // We changed, so rerun all subscribed effects
       // We need to copy the effects set because rerunning an effect might resubscribe it
-      for (const effect of [...effects]) {
-        effect.rerun();
-      }
+      unstable_batchedUpdates(() => {
+        for (const effect of [...effects]) {
+          effect.rerun();
+        }
+      });
     },
   };
 }


### PR DESCRIPTION
I've noticed degraded performance when working with a large number of components on the screen during a color scheme change, especially noticeable on dev builds.

It seems to occur when each component gets re-rendered after `effect.rerun()` call.
Batching `setState` statements that happen after `rerun` resolves that issue.

| Before (Release)       | After (Release)         |
| ---------- |-----------|
|![](https://github.com/marklawlor/nativewind/assets/10130569/4ff04c47-a105-4d95-b003-98741f789d9c)|![](https://github.com/marklawlor/nativewind/assets/10130569/2d267f58-1128-4fbf-9728-fd3370e230b9) |

Not sure if it is a good long-term solution.
