### PR TITLE
Escape windows path during metro transform [2]

### DIFF
--- a/packages/nativewind/src/metro/transformer.ts
+++ b/packages/nativewind/src/metro/transformer.ts
@@ -22,7 +22,7 @@ export async function transform(
         config,
         projectRoot,
         filename,
-        Buffer.from(`require('${config.nativewind.output}');`, "utf8"),
+        Buffer.from(`require('${config.nativewind.output.replace(/\\/g, '\\\\')}');`, "utf8"),
         options,
       );
     } else {


### PR DESCRIPTION
**Original idea and solution was by @sxxov in #743**
I reupload the same solution because original one was overwritten in this commit (as was mentioned and found by @Olgsie in #610):
[72ff611#diff-3b3d28940d6e4a5ad11860e5a017afef5641e4f9becc71e403a638a77ed76539R24](https://github.com/marklawlor/nativewind/commit/72ff611cc4fb08ca9e6265d6e1496e4b64a7de78#diff-3b3d28940d6e4a5ad11860e5a017afef5641e4f9becc71e403a638a77ed76539R24) 

The original issue is #610 related to hanging build for web version in v4